### PR TITLE
fix: extract timeslot from min-fails messages

### DIFF
--- a/Taskfile
+++ b/Taskfile
@@ -13,7 +13,7 @@ playwright:local() {
     --volume .:/app:rw --env BASE_URL="$BASE_URL" \
     --env ASTRO_TELEMETRY_DISABLED=1 \
     "mcr.microsoft.com/playwright:$(_playwright_version)" \
-    bash -c "cd /app; yarn playwright test"
+    bash -c "cd /app; yarn playwright test $*"
 }
 
 # works on my machine™  —dukeceph
@@ -28,7 +28,7 @@ playwright:ui() {
     --volume .:/app:rw --env BASE_URL="$BASE_URL" \
     --env ASTRO_TELEMETRY_DISABLED=1 \
     "mcr.microsoft.com/playwright:$(_playwright_version)" \
-    /bin/bash -c "cd /app; yarn playwright test --ui"
+    /bin/bash -c "cd /app; yarn playwright test --ui $*"
 }
 
 lint:fix() {

--- a/e2e/pages/initiator-tools/min-fails-generator.spec.ts
+++ b/e2e/pages/initiator-tools/min-fails-generator.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => void (await page.goto('/initiator-tools/min-fails-generator')));
+
 test('has title', async ({ page }) => {
 	await expect(page).toHaveTitle(/Min Fails Generator/i);
 });
@@ -20,11 +21,11 @@ test('generates output', async ({ page }) => {
 	await expect(page.getByText('Copy to Clipboard').nth(0)).toBeVisible();
 });
 
-test('extracts timeslot', async ({ page }) => {
+test.only('extracts timeslot', async ({ page, context }) => {
 	await page.getByRole('textbox').fill(`
 		## Minimum check for :egg_unknown: Contract Name
 		### Formula \`Majeggstics 24h\`, Timeslot :one:
 	`);
 
-	await expect(page.getByText('+1 Coops in danger')).toBeVisible();
+	await expect(page.getByRole('heading', { name: /coops in danger/i })).toContainText('+1');
 });

--- a/e2e/pages/initiator-tools/min-fails-generator.spec.ts
+++ b/e2e/pages/initiator-tools/min-fails-generator.spec.ts
@@ -7,7 +7,7 @@ test('has title', async ({ page }) => {
 
 test('generates output', async ({ page }) => {
 	await page.getByRole('textbox').fill(`
-		## Minimum check for <:egg_rocketfuel:455468270661795850> Launch Window
+		## Minimum check for <:egg_unknown:> Contract Name
 		### Formula \`Majeggstics 24h\`, Timeslot :two:
 		** **
 		<:grade_aaa:111> [**\`coop\`**](<carpet>) ([**thread**](<discord_url_1>))
@@ -18,4 +18,13 @@ test('generates output', async ({ page }) => {
 	`);
 
 	await expect(page.getByText('Copy to Clipboard').nth(0)).toBeVisible();
+});
+
+test('extracts timeslot', async ({ page }) => {
+	await page.getByRole('textbox').fill(`
+		## Minimum check for :egg_unknown: Contract Name
+		### Formula \`Majeggstics 24h\`, Timeslot :one:
+	`);
+
+	await expect(page.getByText('+1 Coops in danger')).toBeVisible();
 });

--- a/e2e/pages/initiator-tools/min-fails-generator.spec.ts
+++ b/e2e/pages/initiator-tools/min-fails-generator.spec.ts
@@ -21,7 +21,7 @@ test('generates output', async ({ page }) => {
 	await expect(page.getByText('Copy to Clipboard').nth(0)).toBeVisible();
 });
 
-test.only('extracts timeslot', async ({ page, context }) => {
+test('extracts timeslot', async ({ page }) => {
 	await page.getByRole('textbox').fill(`
 		## Minimum check for :egg_unknown: Contract Name
 		### Formula \`Majeggstics 24h\`, Timeslot :one:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,9 @@ const typeScriptRuleset = merge(...typescript, {
 
 		// those aren't absolute paths; ref tsconfig .compilerOptions.paths
 		'import-x/no-absolute-path': 'off',
+
+		// i don't prefer that, sorry
+		'unicorn/prefer-string-replace-all': 'off',
 	},
 	settings: {
 		'import/resolver': {

--- a/src/components/initiator-tools.spec.ts
+++ b/src/components/initiator-tools.spec.ts
@@ -1,8 +1,31 @@
 import * as chai from 'chai';
-import { parseNotInMessage } from './initiator-tools';
+import { Timeslot, parseNotInMessage } from './initiator-tools';
 
 chai.config.truncateThreshold = 0;
 const expect = chai.expect;
+
+describe('Timeslot#fromWonkyMessage', () => {
+	it('should parse from a min-fails message', () => {
+		const timeslot = Timeslot.fromWonkyMessage(`
+			## Minimum check for :egg_unknown: Contract Name
+			### Formula \`Majeggstics 24h\`, Timeslot :one:
+		`);
+
+		expect(timeslot.index).to.equal(0);
+	});
+
+	it('should parse from notins message', () => {
+		const timeslot = Timeslot.fromWonkyMessage(`
+			Not in <:egg:1> **Contract** <:egg:1> - \`contract-id\`:
+			Timeslot :three::
+			<:grade_aaa:1> [code](<carpet>) ([thread](<discord>)): <@11> (\`foo\`)
+
+			(no pings were sent)
+		`);
+
+		expect(timeslot.index).to.equal(2);
+	});
+});
 
 describe('parseNotInMessage', () => {
 	it('should parse an empty message', () => {

--- a/src/components/initiator-tools.spec.ts
+++ b/src/components/initiator-tools.spec.ts
@@ -11,7 +11,7 @@ describe('Timeslot#fromWonkyMessage', () => {
 			### Formula \`Majeggstics 24h\`, Timeslot :one:
 		`);
 
-		expect(timeslot.index).to.equal(0);
+		expect(timeslot?.index).to.equal(0);
 	});
 
 	it('should parse from notins message', () => {
@@ -23,7 +23,7 @@ describe('Timeslot#fromWonkyMessage', () => {
 			(no pings were sent)
 		`);
 
-		expect(timeslot.index).to.equal(2);
+		expect(timeslot?.index).to.equal(2);
 	});
 });
 

--- a/src/components/initiator-tools.ts
+++ b/src/components/initiator-tools.ts
@@ -7,7 +7,7 @@ const timeslotFormatMap = {
 	header: ['Timeslot 1', 'Timeslot 2', 'Timeslot 3'],
 } as const;
 
-const timeslotHeaderRegex = /Timeslot\s*(?<emoji>:[a-z]+:):/;
+const timeslotHeaderRegex = /Timeslot\s*(?<emoji>:[a-z]+:)/;
 
 export class Timeslot {
 	static One = new Timeslot(0);

--- a/src/components/initiator-tools/min-fails-generator.tsx
+++ b/src/components/initiator-tools/min-fails-generator.tsx
@@ -41,26 +41,15 @@ export default function MinFailsGeneratorPage() {
 		}
 	};
 
-	const contractEgg =
-		/Minimum check for.*?<(?<egg>:.*:).*>.*/.exec(notInMessage)?.groups!.egg ?? '';
-	const contractName =
-		/Minimum check for.*?>(?<timeslot>.*)/.exec(notInMessage)?.groups!.timeslot ?? '';
+	const headerRegex = /Minimum check for\s*<?(?<contractEgg>:.*:)(?:\d+>)?\s*(?<contractName>.*)/;
+	const { contractEgg, contractName } = headerRegex.exec(notInMessage)?.groups! || {};
 
-	const twentyFourHourNotins = notInMessage
-		.slice()
-		.split('\n')
-		.filter((elem) => elem?.toLowerCase().includes('missing'))
-		.map((elem) =>
-			elem
-				?.replace('* ', '')
-				?.replace(' is missing.', '')
-				?.concat(', failure to join after 24 hours'),
-		);
+	const notinRows = notInMessage.split('\n');
+	const twentyFourHourNotins = notinRows
+		.filter((elem) => elem.toLowerCase().includes('missing'))
+		.map((elem) => elem.replace(/(?:^\*| is missing.)/g, '') + ', failure to join after 24 hours');
 
-	const coopsInDanger = notInMessage
-		.slice()
-		.split('\n')
-		.filter((elem) => elem?.toLowerCase().includes(':warning'));
+	const coopsInDanger = notinRows.filter((elem) => elem.toLowerCase().includes(':warning'));
 
 	const contractNameWithTimeslot = `${nitroMode ? contractEgg : ''} ${contractName} ${timeslot?.format('eggst')}`;
 

--- a/src/components/initiator-tools/min-fails-generator.tsx
+++ b/src/components/initiator-tools/min-fails-generator.tsx
@@ -18,9 +18,9 @@ export default function MinFailsGeneratorPage() {
 		.filter((elem) => elem?.toLowerCase().includes('spent'))
 		.map((elem) =>
 			elem
-				?.replace('<:b_icon_token:1123683788258549861>', ':b_icon_token:')
-				?.replace('<:clock:1123686591412576357>', ':clock:')
-				?.replace('* ', '- '),
+				.replace('<:b_icon_token:1123683788258549861>', ':b_icon_token:')
+				.replace('<:clock:1123686591412576357>', ':clock:')
+				.replace('* ', '- '),
 		);
 
 	const [copiedElements, setCopiedElements] = useState<boolean[]>(
@@ -42,12 +42,12 @@ export default function MinFailsGeneratorPage() {
 	};
 
 	const headerRegex = /Minimum check for\s*<?(?<contractEgg>:.*:)(?:\d+>)?\s*(?<contractName>.*)/;
-	const { contractEgg, contractName } = headerRegex.exec(notInMessage)?.groups! || {};
+	const { contractEgg, contractName } = headerRegex.exec(notInMessage)?.groups ?? {};
 
 	const notinRows = notInMessage.split('\n');
 	const twentyFourHourNotins = notinRows
 		.filter((elem) => elem.toLowerCase().includes('missing'))
-		.map((elem) => elem.replace(/(?:^\*| is missing.)/g, '') + ', failure to join after 24 hours');
+		.map((elem) => elem.replace(/^\*| is missing./g, '') + ', failure to join after 24 hours');
 
 	const coopsInDanger = notinRows.filter((elem) => elem.toLowerCase().includes(':warning'));
 

--- a/src/pages/guide.mdx
+++ b/src/pages/guide.mdx
@@ -184,58 +184,64 @@ lobby.
 [hashtru]: https://hashtru.netlify.app/contractboost/
 
 ## Boosting
-* Use [GomCalc ↗][gomcalc], [SaladForks’ Egg Inc Tools ↗][saladforks], and [Hashtru’s Contract Boost Calculator ↗][hashtru]
-to help determine the best boost combination for your goals. These will vary widely depending
-on the contract, number of players in your group, your EB, and artifacts.
-  * Most players can use a **Legendary Tachyon Prism** & **Epic Boost Beacon** to
-  completely fill habs.
-  * Players with Tier 4 Artifacts can often use **two Epic Tachyon Prisms** (together or
-  separately) to fill habs over 50%.
-  * Advanced artifact players with powerful dilithium and life sets can often hablock
-  with a single Epic Tachyon and a few chicken runs post-boost. A powerful tachyon
-  artifact set can result in shipping locking.
-  * Consider the number of people in your contract and the impact deflectors will have
-  on your laying rate — choose more GE efficient boosts in larger co-ops.
-* Before boosting, equip artifacts with <b>dilithium stones</b> to increase your boost
-time.
-* Immediately after starting your boosts, switch to your best **monocle**, **chalice**,
-and **artifacts with life stones**. Leave the farm to take advantage of the Internal
-Hatchery Calm Epic Research. If needed, equip a **gusset** to increase hab space.
+
+- Use [GomCalc ↗][gomcalc], [SaladForks’ Egg Inc Tools ↗][saladforks], and [Hashtru’s Contract Boost Calculator ↗][hashtru]
+  to help determine the best boost combination for your goals. These will vary widely depending
+  on the contract, number of players in your group, your EB, and artifacts.
+  - Most players can use a **Legendary Tachyon Prism** & **Epic Boost Beacon** to
+    completely fill habs.
+  - Players with Tier 4 Artifacts can often use **two Epic Tachyon Prisms** (together or
+    separately) to fill habs over 50%.
+  - Advanced artifact players with powerful dilithium and life sets can often hablock
+    with a single Epic Tachyon and a few chicken runs post-boost. A powerful tachyon
+    artifact set can result in shipping locking.
+  - Consider the number of people in your contract and the impact deflectors will have
+    on your laying rate — choose more GE efficient boosts in larger co-ops.
+- Before boosting, equip artifacts with <b>dilithium stones</b> to increase your boost
+  time.
+- Immediately after starting your boosts, switch to your best **monocle**, **chalice**,
+  and **artifacts with life stones**. Leave the farm to take advantage of the Internal
+  Hatchery Calm Epic Research. If needed, equip a **gusset** to increase hab space.
 
 ## Post-boosting
-* **Tachyon Deflectors** boost your co-op mates' laying rates — since Majeggstics aim
-for equal contributions, a deflector will benefit your co-op overall more than any
-artifact that only works on your individual farm.
-* **Metronome** and artifacts with **tachyon stones** boost egg laying rate.
-* **Compass** and artifacts with **quantum stones** increase shipping rate.
-* **Check in regularly** and don’t let your chickens fall asleep!
-  * The game does not update automatically. You must open your co-op farm and sync with
-  the server for us to see your earnings before minimums are checked. Please check-in 15
-  minutes before your minimum check and confirm your lay rate using the eicoop link in
-  your thread to avoid getting a strike.
-* **Contact a token:**
-  * If you see glitching in your group. Glitching is not allowed in Majeggstics co-ops.
-  * Enforcing minimum is the responsibility of tokens. Do not ping low performing
-  members yourself, allow tokens to contact them and offer support.
-  * Removing members from our contracts is not allowed. If you remove Majeggstics
-  players from our co-op without specific instructions from a token, you will be removed
-  from Majeggstics.
+
+- **Tachyon Deflectors** boost your co-op mates' laying rates — since Majeggstics aim
+  for equal contributions, a deflector will benefit your co-op overall more than any
+  artifact that only works on your individual farm.
+- **Metronome** and artifacts with **tachyon stones** boost egg laying rate.
+- **Compass** and artifacts with **quantum stones** increase shipping rate.
+- **Check in regularly** and don’t let your chickens fall asleep!
+  - The game does not update automatically. You must open your co-op farm and sync with
+    the server for us to see your earnings before minimums are checked. Please check-in 15
+    minutes before your minimum check and confirm your lay rate using the eicoop link in
+    your thread to avoid getting a strike.
+- **Contact a token:**
+  - If you see glitching in your group. Glitching is not allowed in Majeggstics co-ops.
+  - Enforcing minimum is the responsibility of tokens. Do not ping low performing
+    members yourself, allow tokens to contact them and offer support.
+  - Removing members from our contracts is not allowed. If you remove Majeggstics
+    players from our co-op without specific instructions from a token, you will be removed
+    from Majeggstics.
 
 ## Completion
-* Check in ASAP after the contract has finished so that your contract score can be calculated.{' '}
+
+- Check in ASAP after the contract has finished so that your contract score can be calculated.{' '}
 
 ## Taking Breaks & Leaving
+
 We’re here to help you be successful with contracts, but we understand that sometimes
 you need a break.
-* **Not registering**: you can skip registering for contracts with us whenever you like
-with no penalties.
-* **Leaving the group**: if you’re not enjoying being a Majeggstic, want to join another
-Wonky group, or are retiring from the game, ping our Member Manager and ask to be
-removed from Majeggstics.
-* **Staying to socialize**: If you quit playing but enjoy the community, you can stay in
-the group. You don’t have to play Egg Inc, and we enjoy having friends!
+
+- **Not registering**: you can skip registering for contracts with us whenever you like
+  with no penalties.
+- **Leaving the group**: if you’re not enjoying being a Majeggstic, want to join another
+  Wonky group, or are retiring from the game, ping our Member Manager and ask to be
+  removed from Majeggstics.
+- **Staying to socialize**: If you quit playing but enjoy the community, you can stay in
+  the group. You don’t have to play Egg Inc, and we enjoy having friends!
 
 ## Code of Conduct
+
 Is it a privilege for Majeggstics to have access to private channels and Wonky in the
 Egg, Inc. server. Because of our special status, we have high expectations for your
 behavior in our channels and around the server.
@@ -245,66 +251,68 @@ behavior in our channels and around the server.
 [dialectical]: https://dialecticalbehaviortherapy.com/
 [projectlets]: https://projectlets.org
 
-* <strong>[Follow server \#rules ↗](rules). Majeggstics members and channels must follow
-the Egg, Inc. server rules. Violating server rules will lead to removal from Majeggstics
-and the Egg, Inc. server.</strong>
-* Keep chat in Majeggstics kind and appropriate for all, and be a good representative of
-Majeggstics in public channels.
-* Respect Majeggstics tokens when asked to change your behavior.
-* Current events and politics can only be discussed in Off-Topic &gt;#current-events.
-* Majeggstics is a friendly and caring group of people, but we are limited in the
-support we can provide. If you need to chat about mental health, check out:
-  * [7 Cups of Tea ↗][7cups]: Free 24/7 chat by trained volunteers.
-  * [Dialectical Behaviour Therapy ↗][dialectical]: Free, anonymous, independent skills
-  and tools to help manage big feelings.
-  * [Project Lets ↗][projectlets]: Community-support based mental health care, by and
-  for folks with lived experience of mental illness/madness, Disability, trauma, &
-  neurodivergence.
-* Majeggstics has a system for recruiting that respects server rules and makes sure new
-members are a good fit for our group and play style.
-  * Respect server rules about recruitment and co-op chat.
-  * Check the pins in Co-op Recruitment > \#?-grade-coops to make sure we are
-  currently recruiting, and have friends follow the instructions in our pinned post.
-  * People struggling with public co-ops may not be a good fit for Majeggstics. Let them
-  know about Co-Op Recruitment channels and the pinned posts, and allow them to choose
-  the group that’s right for them.
-* Keep chat about Majeggstics and Wonky in our channels — in public channels this often
-becomes recruitment or bragging, and reflects poorly on our group.
-* There are many private co-op groups in the server, with different play styles and
-requirements for joining. Be respectful of the other groups and how they play the game,
-even if it’s different from us.
-* You will be removed from Majeggstics for glitching/cheating in our co-ops.
-  * Server staff are notified of cheating players and may apply server-wide penalties.
-* Use bot commands channels instead of discussion channels to send commands:
-  * Utilities > \#bot-commands
-  * Wonky > \#public-wonky-commands
-  * Majeggstics > \# wonky-spam
-* Don’t try to break bots, and be patient when bots are down.
-* Keep spam in Off Topic > \#spam.
-* Direct Messages (DM)
-  * Majeggstics is privileged to have threads for all of our co-ops — ping members in
-  your thread instead of sending a DM or sending tokens in-game.
-  * Use Majeggstics and server channels to ask general questions instead of sending DMs
-  to other players, tokens, or server staff.
-  * If you see inappropriate chat in Majeggstics channels, or glitching in our co-ops,
-  you can react with the :flag_white: emoji to notify Majeggstics Tokens. Wonky will
-  automatically remove your reaction to protect your privacy, and Tokens will get a copy
-  of the message.
-  * Follow instructions in Utilities > \#ticket-tool for help from server staff
-  (unwanted/inappropriate DMs, glitching in non-Majeggstic co-ops, etc.)
-
+- <strong>
+  	[Follow server \#rules ↗](rules). Majeggstics members and channels must follow the Egg, Inc.
+  	server rules. Violating server rules will lead to removal from Majeggstics and the Egg, Inc.
+  	server.
+  </strong>
+- Keep chat in Majeggstics kind and appropriate for all, and be a good representative of
+  Majeggstics in public channels.
+- Respect Majeggstics tokens when asked to change your behavior.
+- Current events and politics can only be discussed in Off-Topic &gt;#current-events.
+- Majeggstics is a friendly and caring group of people, but we are limited in the
+  support we can provide. If you need to chat about mental health, check out:
+  - [7 Cups of Tea ↗][7cups]: Free 24/7 chat by trained volunteers.
+  - [Dialectical Behaviour Therapy ↗][dialectical]: Free, anonymous, independent skills
+    and tools to help manage big feelings.
+  - [Project Lets ↗][projectlets]: Community-support based mental health care, by and
+    for folks with lived experience of mental illness/madness, Disability, trauma, &
+    neurodivergence.
+- Majeggstics has a system for recruiting that respects server rules and makes sure new
+  members are a good fit for our group and play style.
+  - Respect server rules about recruitment and co-op chat.
+  - Check the pins in Co-op Recruitment > \#?-grade-coops to make sure we are
+    currently recruiting, and have friends follow the instructions in our pinned post.
+  - People struggling with public co-ops may not be a good fit for Majeggstics. Let them
+    know about Co-Op Recruitment channels and the pinned posts, and allow them to choose
+    the group that’s right for them.
+- Keep chat about Majeggstics and Wonky in our channels — in public channels this often
+  becomes recruitment or bragging, and reflects poorly on our group.
+- There are many private co-op groups in the server, with different play styles and
+  requirements for joining. Be respectful of the other groups and how they play the game,
+  even if it’s different from us.
+- You will be removed from Majeggstics for glitching/cheating in our co-ops.
+  - Server staff are notified of cheating players and may apply server-wide penalties.
+- Use bot commands channels instead of discussion channels to send commands:
+  - Utilities > \#bot-commands
+  - Wonky > \#public-wonky-commands
+  - Majeggstics > \# wonky-spam
+- Don’t try to break bots, and be patient when bots are down.
+- Keep spam in Off Topic > \#spam.
+- Direct Messages (DM)
+  - Majeggstics is privileged to have threads for all of our co-ops — ping members in
+    your thread instead of sending a DM or sending tokens in-game.
+  - Use Majeggstics and server channels to ask general questions instead of sending DMs
+    to other players, tokens, or server staff.
+  - If you see inappropriate chat in Majeggstics channels, or glitching in our co-ops,
+    you can react with the :flag_white: emoji to notify Majeggstics Tokens. Wonky will
+    automatically remove your reaction to protect your privacy, and Tokens will get a copy
+    of the message.
+  - Follow instructions in Utilities > \#ticket-tool for help from server staff
+    (unwanted/inappropriate DMs, glitching in non-Majeggstic co-ops, etc.)
 
 ## Useful Links
 
-* [Server \#rules ↗](https://discord.com/channels/455380663013736479/972559672814993418/972560766957924442)
-* [Ciria’s Useful Links Pin in \#the_majeggstics ↗](https://discord.com/chttps://discord.com/channels/455380663013736479/807641608538292254/1121583305410740314hannels/455380663013736479/807641608538292254/1121583305410740314)
-* [Ciria’s Amazing Infographics Thread in \#the_majeggstics ↗](https://discord.com/channels/455380663013736479/1121015323005554808)
-* [\#artichat ↗](https://discord.com/channels/455380663013736479/801187025742331996)
-  * Artifacts, crafting XP, ship drops, material farming, sets
-* [\#tips-and-tricks ↗](https://discord.com/channels/455380663013736479/455385659079917569)
-  * Prestige strategies, fuel guides, diamond trophy guide, Royal Physique’s Epic Research calculator
+- [Server \#rules ↗](https://discord.com/channels/455380663013736479/972559672814993418/972560766957924442)
+- [Ciria’s Useful Links Pin in \#the_majeggstics ↗](https://discord.com/chttps://discord.com/channels/455380663013736479/807641608538292254/1121583305410740314hannels/455380663013736479/807641608538292254/1121583305410740314)
+- [Ciria’s Amazing Infographics Thread in \#the_majeggstics ↗](https://discord.com/channels/455380663013736479/1121015323005554808)
+- [\#artichat ↗](https://discord.com/channels/455380663013736479/801187025742331996)
+  - Artifacts, crafting XP, ship drops, material farming, sets
+- [\#tips-and-tricks ↗](https://discord.com/channels/455380663013736479/455385659079917569)
+  - Prestige strategies, fuel guides, diamond trophy guide, Royal Physique’s Epic Research calculator
 
 ## Joining Majeggstics
+
 Ready to get started?
 
 Open the game and find your **EID**: Open the ‘9 dots’ menu, touch ‘Help’, then ‘Data

--- a/src/pages/initiator-tools/min-fails-generator.astro
+++ b/src/pages/initiator-tools/min-fails-generator.astro
@@ -4,5 +4,5 @@ import MinFailsGenerator from '/components/initiator-tools/min-fails-generator';
 ---
 
 <Layout title="Min Fails Generator">
-	<MinFailsGenerator client:load />
+	<MinFailsGenerator client:only="react" />
 </Layout>

--- a/src/pages/initiator-tools/notin-fails-generator.astro
+++ b/src/pages/initiator-tools/notin-fails-generator.astro
@@ -4,5 +4,5 @@ import NotinFailsGenerator from '/components/initiator-tools/notin-fails-generat
 ---
 
 <Layout title="Notin Fails Generator">
-	<NotinFailsGenerator client:load />
+	<NotinFailsGenerator client:only="react" />
 </Layout>

--- a/src/pages/initiator-tools/notin-message-generator.astro
+++ b/src/pages/initiator-tools/notin-message-generator.astro
@@ -4,5 +4,5 @@ import NotinMessageGenerator from '/components/initiator-tools/notin-message-gen
 ---
 
 <Layout title="Notin Message Generator">
-	<NotinMessageGenerator client:load />
+	<NotinMessageGenerator client:only="react" />
 </Layout>


### PR DESCRIPTION
Timeslot extraction regex was tuned only for notin messages, where `Timeslot :number:` is followed by a colon. I observed the new tests failing, removed the colon from the regex, and observed them pass.