### PR TITLE
refactor: tidy up min-fails-generator a bit...

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -2,5 +2,5 @@
 	"$schema": "https://json.schemastore.org/lintstagedrc.schema.json",
 	"*": "prettier --ignore-unknown --write",
 	"**/*.{mjs,js,cjs,ts,tsx,astro}": "eslint --fix",
-	"src/**.ts": "mocha src/**/*.spec.ts"
+	"src/**.ts": "yarn typecheck && mocha src/**/*.spec.ts"
 }

--- a/e2e/pages/initiator-tools/min-fails-generator.spec.ts
+++ b/e2e/pages/initiator-tools/min-fails-generator.spec.ts
@@ -3,12 +3,12 @@ import { expect, test } from '@playwright/test';
 test.beforeEach(async ({ page }) => void (await page.goto('/initiator-tools/min-fails-generator')));
 
 test('has title', async ({ page }) => {
-	await expect(page).toHaveTitle(/Min Fails Generator/i);
+	await expect(page).toHaveTitle(/min fails generator/i);
 });
 
 test('generates output', async ({ page }) => {
 	await page.getByRole('textbox').fill(`
-		## Minimum check for <:egg_unknown:> Contract Name
+		## Minimum check for <:egg_unknown:111> Contract Name
 		### Formula \`Majeggstics 24h\`, Timeslot :two:
 		** **
 		<:grade_aaa:111> [**\`coop\`**](<carpet>) ([**thread**](<discord_url_1>))

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,7 @@
+import tsParser from '@typescript-eslint/parser';
+import astroParser from 'astro-eslint-parser';
+import astro from 'eslint-config-neon/astro';
 import common from 'eslint-config-neon/common';
-import node from 'eslint-config-neon/node';
 import prettier from 'eslint-config-neon/prettier';
 import react from 'eslint-config-neon/react';
 import typescript from 'eslint-config-neon/typescript';
@@ -9,14 +11,22 @@ const commonFiles = '{js,mjs,cjs,ts,mts,cts,jsx,tsx}';
 
 const commonRuleset = merge(...common, { files: [`**/*${commonFiles}`] });
 
-const nodeRuleset = merge(...node, { files: [`**/*${commonFiles}`] });
-
 const prettierRuleset = merge(...prettier, { files: [`**/*${commonFiles}`] });
 
 const reactRuleset = merge(...react, {
 	files: [`**/*${commonFiles}`],
 	rules: {
-		'react/button-has-type': 0,
+		'react/button-has-type': 'off',
+	},
+});
+
+const astroRuleset = merge(...astro, {
+	files: [`**/*.astro`],
+	languageOptions: {
+		parser: astroParser,
+		parserOptions: {
+			parser: tsParser,
+		},
 	},
 });
 
@@ -53,15 +63,15 @@ const typeScriptRuleset = merge(...typescript, {
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [
 	{
-		ignores: ['**/node_modules/', '.git/', '**/dist/'],
+		ignores: ['**/node_modules/', '.git/', 'out/'],
 	},
 	{
 		files: ['**/*{js,mjs,cjs,jsx}'],
-		rules: { 'tsdoc/syntax': 0 },
+		rules: { 'tsdoc/syntax': 'off' },
 	},
 	commonRuleset,
-	// nodeRuleset,
 	reactRuleset,
 	typeScriptRuleset,
 	prettierRuleset,
+	astroRuleset,
 ];

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
 		"@types/prop-types": "^15.7.13",
 		"@types/react": "^18.3.9",
 		"@types/react-dom": "^18.3.0",
+		"@typescript-eslint/parser": "^8.7.0",
+		"astro-eslint-parser": "^1.0.3",
 		"chai": "^5.1.1",
 		"common-tags": "^1.8.2",
 		"eslint": "^8.57.1",

--- a/src/components/initiator-tools.ts
+++ b/src/components/initiator-tools.ts
@@ -96,6 +96,7 @@ export const parseNotInMessage = (input: string): NotInsPerTimeslot => {
 				const notins: NotIns[] = match
 					?.groups!.notins!.trim()
 					.split('\n')
+					.filter((line) => line.length > 0)
 					.map((line) => {
 						const httpUrl = /\[thread]\(<(?<url>[^>]+)>\)/.exec(line)?.groups!.url;
 						const threadUrl = httpUrl ? convertToDiscordUrl(httpUrl.trim()) : null;

--- a/src/components/initiator-tools/min-fails-generator.tsx
+++ b/src/components/initiator-tools/min-fails-generator.tsx
@@ -1,6 +1,5 @@
 import copy from 'copy-to-clipboard';
 import { useState } from 'react';
-import ToastMessage from '/components/ToastMessage';
 import { Timeslot } from '/components/initiator-tools';
 import { notify, useEventSetState, useToggleState } from '/lib/utils';
 

--- a/src/components/initiator-tools/notin-message-generator.tsx
+++ b/src/components/initiator-tools/notin-message-generator.tsx
@@ -1,7 +1,6 @@
 // Currently doesn't support Wonky's "(from timeslot xx)"
 import copy from 'copy-to-clipboard';
 import { Fragment, useState, useCallback, useMemo } from 'react';
-import ToastMessage from '/components/ToastMessage';
 import { css } from '@acab/ecsstatic';
 import { Timeslot, useExtractNotins, type UserSpec } from '/components/initiator-tools';
 import { notify, useEventSetState } from '/lib/utils';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,11 @@
-import type { ChangeEvent, ChangeEventHandler, Dispatch, SetStateAction } from 'react';
+import type {
+	ChangeEvent,
+	ChangeEventHandler,
+	Dispatch,
+	EventHandler,
+	SetStateAction,
+	SyntheticEvent,
+} from 'react';
 import { useState, useCallback } from 'react';
 import { toast } from 'react-toastify';
 
@@ -16,7 +23,7 @@ export const useEventSetState = (
 
 export const useToggleState = (
 	initial: boolean = false,
-): [boolean, Dispatch<SetStateAction<void>>, Dispatch<SetStateAction<boolean>>] => {
+): [boolean, EventHandler<SyntheticEvent<any, Event>>, Dispatch<SetStateAction<boolean>>] => {
 	const [rawState, setRawState] = useState<boolean>(initial);
 	return [rawState, useCallback(() => setRawState((state) => !state), []), setRawState];
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,6 +14,13 @@ export const useEventSetState = (
 	];
 };
 
+export const useToggleState = (
+	initial: boolean = false,
+): [boolean, Dispatch<SetStateAction<void>>, Dispatch<SetStateAction<boolean>>] => {
+	const [rawState, setRawState] = useState<boolean>(initial);
+	return [rawState, useCallback(() => setRawState((state) => !state), []), setRawState];
+};
+
 export function notify(message: string, type = 'default') {
 	switch (type) {
 		case 'info':

--- a/src/pages/initiator-tools/min-fails-generator.astro
+++ b/src/pages/initiator-tools/min-fails-generator.astro
@@ -4,5 +4,6 @@ import MinFailsGenerator from '/components/initiator-tools/min-fails-generator';
 ---
 
 <Layout title="Min Fails Generator">
+	<h1>Minimum Fails Generator</h1>
 	<MinFailsGenerator client:only="react" />
 </Layout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2166,48 +2166,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/core@npm:1.18.0":
-  version: 1.18.0
-  resolution: "@shikijs/core@npm:1.18.0"
+"@shikijs/core@npm:1.19.0":
+  version: 1.19.0
+  resolution: "@shikijs/core@npm:1.19.0"
   dependencies:
-    "@shikijs/engine-javascript": "npm:1.18.0"
-    "@shikijs/engine-oniguruma": "npm:1.18.0"
-    "@shikijs/types": "npm:1.18.0"
+    "@shikijs/engine-javascript": "npm:1.19.0"
+    "@shikijs/engine-oniguruma": "npm:1.19.0"
+    "@shikijs/types": "npm:1.19.0"
     "@shikijs/vscode-textmate": "npm:^9.2.2"
     "@types/hast": "npm:^3.0.4"
     hast-util-to-html: "npm:^9.0.3"
-  checksum: 10/3160e01117b80d846472473c925614fcf1f10a5722431e014d9a1e61b90e0d145f801ceb1773e4368b046f67080236f0d124a99a8ae6a4dab68accd7f14ce992
+  checksum: 10/263fe2ee9699435f6d878fb4f8b7d2d2a99acd5369c636c55a8e54eca22184d25a84be325c60711247a5235c4957d82923650b1c1b7057330586c01d8f0b82b7
   languageName: node
   linkType: hard
 
-"@shikijs/engine-javascript@npm:1.18.0":
-  version: 1.18.0
-  resolution: "@shikijs/engine-javascript@npm:1.18.0"
+"@shikijs/engine-javascript@npm:1.19.0":
+  version: 1.19.0
+  resolution: "@shikijs/engine-javascript@npm:1.19.0"
   dependencies:
-    "@shikijs/types": "npm:1.18.0"
+    "@shikijs/types": "npm:1.19.0"
     "@shikijs/vscode-textmate": "npm:^9.2.2"
     oniguruma-to-js: "npm:0.4.3"
-  checksum: 10/8840834ccba9f6145b13fee6662507607dbac72daa39c28176fa630357861a96fc3a9bb9bc92c0ed7b69856cd1e6210964e8376b7620c9969704c6a8b76e2f42
+  checksum: 10/362759c30801980b3885bf4cad3902e5eaad81683c31ef72b04d2cc9cc928d79043ce84d7b4cbe8decb93003d76a295a9b5ea5d0e1d583b3a12acdf4ad0bd536
   languageName: node
   linkType: hard
 
-"@shikijs/engine-oniguruma@npm:1.18.0":
-  version: 1.18.0
-  resolution: "@shikijs/engine-oniguruma@npm:1.18.0"
+"@shikijs/engine-oniguruma@npm:1.19.0":
+  version: 1.19.0
+  resolution: "@shikijs/engine-oniguruma@npm:1.19.0"
   dependencies:
-    "@shikijs/types": "npm:1.18.0"
+    "@shikijs/types": "npm:1.19.0"
     "@shikijs/vscode-textmate": "npm:^9.2.2"
-  checksum: 10/255a7bddfa2d1e993c11e97395aca6be66b9a751a2c64e9c8dedc138395fe017f46ccadc4906d689688256eadc7a15d8fb32b8299238f34557945f318dab1fd2
+  checksum: 10/5c75e489f9a88aad71f3b231575f6da3870d00335d0d241e92abe8e8c629309bef806620f76ceb2e2712eb782b185c8a82fb11edaf75dc683b95a1e911386564
   languageName: node
   linkType: hard
 
-"@shikijs/types@npm:1.18.0":
-  version: 1.18.0
-  resolution: "@shikijs/types@npm:1.18.0"
+"@shikijs/types@npm:1.19.0":
+  version: 1.19.0
+  resolution: "@shikijs/types@npm:1.19.0"
   dependencies:
     "@shikijs/vscode-textmate": "npm:^9.2.2"
     "@types/hast": "npm:^3.0.4"
-  checksum: 10/cb8ec0a145be74698784ca02a7979577e05533407e9d88c040092c7443d81bc1ef19a0b1d0351eb2c0add9902ebeaf8028cb59f5d9f4618dcfa143867a6b7899
+  checksum: 10/38089e90be28d8c636a85e385d858933dfa7aded783e17f6319c1f56d100d1b52168395edf2ac45ff4e65be8d94da657712f8454466df898faff7b5f999f686e
   languageName: node
   linkType: hard
 
@@ -2269,9 +2269,9 @@ __metadata:
   linkType: hard
 
 "@types/chai@npm:^4.3.19":
-  version: 4.3.19
-  resolution: "@types/chai@npm:4.3.19"
-  checksum: 10/5ca7a48ec1c792e536bc228911f442c31eb8a24f1c3531f8a5e1e949590a6a045be17a2ec5a3d83f63dae8d59dd93dc5f6ca7355b9c1a9f003c553a733b2e591
+  version: 4.3.20
+  resolution: "@types/chai@npm:4.3.20"
+  checksum: 10/94fd87036fb63f62c79caf58ccaec88e23cc109e4d41607d83adc609acd6b24eabc345feb7850095a53f76f99c470888251da9bd1b90849c8b2b5a813296bb19
   languageName: node
   linkType: hard
 
@@ -2396,9 +2396,9 @@ __metadata:
   linkType: hard
 
 "@types/lodash@npm:*":
-  version: 4.17.7
-  resolution: "@types/lodash@npm:4.17.7"
-  checksum: 10/b8177f19cf962414a66989837481b13f546afc2e98e8d465bec59e6ac03a59c584eb7053ce511cde3a09c5f3096d22a5ae22cfb56b23f3b0da75b0743b6b1a44
+  version: 4.17.9
+  resolution: "@types/lodash@npm:4.17.9"
+  checksum: 10/49e35caaf668686be0bad9e9bef88456903a21999d3fd8bf91c302e0d5328398fb59fee793d0afbaf6edeca1b46c3e8109899d85ff3a433075178f1ab693e597
   languageName: node
   linkType: hard
 
@@ -2458,20 +2458,20 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 22.5.5
-  resolution: "@types/node@npm:22.5.5"
+  version: 22.7.3
+  resolution: "@types/node@npm:22.7.3"
   dependencies:
     undici-types: "npm:~6.19.2"
-  checksum: 10/172d02c8e6d921699edcf559c28b3805616bd6481af1b3cb0299f89ad9a6f33b71050434c06ce7b503166054a26275344187c443f99f745d0b12601372452f19
+  checksum: 10/f5e450c8c0588506698c6dd5fb9617cc516e2bd35417d853c96378533bc45b69219715ecc5d78667a194387647e69a10852b348b52e2d45f41ec75985cd3ef88
   languageName: node
   linkType: hard
 
 "@types/node@npm:^20.0.0, @types/node@npm:^20.16.5":
-  version: 20.16.5
-  resolution: "@types/node@npm:20.16.5"
+  version: 20.16.9
+  resolution: "@types/node@npm:20.16.9"
   dependencies:
     undici-types: "npm:~6.19.2"
-  checksum: 10/39a8457149dc17cdea57afc90d4da53182fdb8b958d5bb065a15d123d81d4efa6b51a0de92428d05ead2e63ce07195586f71083401b99cdbcd04662344fbf7a1
+  checksum: 10/cc7e57775ce80348f72a7026910ee0082bf3e0f5af33b3cdc3ce10df64e51bb70b0e8ce4726ecf53cc9c4ba239d340d76831de38ecc7e317e41fb71f793b6e93
   languageName: node
   linkType: hard
 
@@ -2498,17 +2498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 18.3.8
-  resolution: "@types/react@npm:18.3.8"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10/75e64e7f481c28e6c8ce6dae12f49ccc3f36c7b10b82da3eb7728ad9c02bec58a2c967105603e38665902e8db9296962c7718bc2062e2cb64a16e92333bd1f4b
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^18.3.9":
+"@types/react@npm:*, @types/react@npm:^18.3.9":
   version: 18.3.9
   resolution: "@types/react@npm:18.3.9"
   dependencies:
@@ -2586,14 +2576,14 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.6.0"
+  version: 8.7.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.7.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.6.0"
-    "@typescript-eslint/type-utils": "npm:8.6.0"
-    "@typescript-eslint/utils": "npm:8.6.0"
-    "@typescript-eslint/visitor-keys": "npm:8.6.0"
+    "@typescript-eslint/scope-manager": "npm:8.7.0"
+    "@typescript-eslint/type-utils": "npm:8.7.0"
+    "@typescript-eslint/utils": "npm:8.7.0"
+    "@typescript-eslint/visitor-keys": "npm:8.7.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -2604,7 +2594,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/8f8c72b47e59973c6aaa955a01d2bce834dbd317b37f66355aba564aa30bed4ed7be26080d20ed2ae834bc628706da534da6a87a9720608835b27f165d59bd2b
+  checksum: 10/5bc774b1da4e1cd19c5ffd731c655c53035fd81ff06a95c2f2c54ab62c401879f886da3e1a1235505341e8172b2841c6edc78b4565a261105ab32d83bf5b8ab1
   languageName: node
   linkType: hard
 
@@ -2637,21 +2627,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/parser@npm:8.6.0"
+"@typescript-eslint/parser@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0, @typescript-eslint/parser@npm:^8.7.0":
+  version: 8.7.0
+  resolution: "@typescript-eslint/parser@npm:8.7.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.6.0"
-    "@typescript-eslint/types": "npm:8.6.0"
-    "@typescript-eslint/typescript-estree": "npm:8.6.0"
-    "@typescript-eslint/visitor-keys": "npm:8.6.0"
+    "@typescript-eslint/scope-manager": "npm:8.7.0"
+    "@typescript-eslint/types": "npm:8.7.0"
+    "@typescript-eslint/typescript-estree": "npm:8.7.0"
+    "@typescript-eslint/visitor-keys": "npm:8.7.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/6e6bb37841665e5fac8c5505a5b755ef499d5caf8cb975043e8b0e459520d315a1c7e7ae60a1d6bc20e7f4193b6d7cb74bc95dede203851087a1713c8d0b8abc
+  checksum: 10/896ac60f8426f9e5c23198c89555f6f88f7957c5b16bb7b966dac45c5f5e7076c1a050bcee2e0eddff88055b9c0d7bdfaef9c64889e3bdf3356d20356b0daa04
   languageName: node
   linkType: hard
 
@@ -2675,13 +2665,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.6.0, @typescript-eslint/scope-manager@npm:^7.0.0 || ^8.0.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.6.0"
+"@typescript-eslint/scope-manager@npm:8.7.0, @typescript-eslint/scope-manager@npm:^7.0.0 || ^8.0.0":
+  version: 8.7.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.7.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.6.0"
-    "@typescript-eslint/visitor-keys": "npm:8.6.0"
-  checksum: 10/4a42020caf1b45f661a2722c60ca3aaec34eb93c39fae71fd7a7d9c7824d2930447ecab1059ed2908e31f9995df37c32e2cb599f0795f01012d6c63847b9e907
+    "@typescript-eslint/types": "npm:8.7.0"
+    "@typescript-eslint/visitor-keys": "npm:8.7.0"
+  checksum: 10/6a6aae28437f6cd78f82dd1359658593fcc8f6d0da966b4d128b14db3a307b6094d22515a79c222055a31bf9b73b73799acf18fbf48c0da16e8f408fcc10464c
   languageName: node
   linkType: hard
 
@@ -2702,18 +2692,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/type-utils@npm:8.6.0"
+"@typescript-eslint/type-utils@npm:8.7.0":
+  version: 8.7.0
+  resolution: "@typescript-eslint/type-utils@npm:8.7.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.6.0"
-    "@typescript-eslint/utils": "npm:8.6.0"
+    "@typescript-eslint/typescript-estree": "npm:8.7.0"
+    "@typescript-eslint/utils": "npm:8.7.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^1.3.0"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/9b537821e180818915e75422a4e4810f7cc87f2223ad7fb145fca76b808f97425f81e4db7909542f76e6b53519f9b3a47d86fc8d1881a156158432c0ba748f89
+  checksum: 10/dba4520dd3dce35b765640f9633100bd29d2092478cb467e89bde51dc23fb19f7395e87f4486b898315aab081263003cbc78f03f0f40079602713aafc2f2a6a5
   languageName: node
   linkType: hard
 
@@ -2731,10 +2721,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.6.0, @typescript-eslint/types@npm:^7.0.0 || ^8.0.0, @typescript-eslint/types@npm:^7.7.1 || ^8":
-  version: 8.6.0
-  resolution: "@typescript-eslint/types@npm:8.6.0"
-  checksum: 10/b89e26ce5aa03be56ad5d261aa28aecf3bab5ba78983ea51630ccaee7c7066489ee7c58fc3f18811c63418c900e69ac2b7d12e206485f45b2331d00d8bdb760f
+"@typescript-eslint/types@npm:8.7.0, @typescript-eslint/types@npm:^7.0.0 || ^8.0.0, @typescript-eslint/types@npm:^7.7.1 || ^8":
+  version: 8.7.0
+  resolution: "@typescript-eslint/types@npm:8.7.0"
+  checksum: 10/9adbe4efdcb00735af5144a161d6bb2f79a952a9701820920ad33adba02032d65d5b601087e953c2918f7efa548abbcd9289f83ec6299f66941d7c585886792e
   languageName: node
   linkType: hard
 
@@ -2775,12 +2765,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.6.0, @typescript-eslint/typescript-estree@npm:^7.0.0 || ^8.0.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.6.0"
+"@typescript-eslint/typescript-estree@npm:8.7.0, @typescript-eslint/typescript-estree@npm:^7.0.0 || ^8.0.0":
+  version: 8.7.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.7.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.6.0"
-    "@typescript-eslint/visitor-keys": "npm:8.6.0"
+    "@typescript-eslint/types": "npm:8.7.0"
+    "@typescript-eslint/visitor-keys": "npm:8.7.0"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -2790,7 +2780,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/34b7920e34860d33e38081c3ca9f780890822c6a28e29804ae053a1a618a45d6513c014dcb46480b10a4ba3c3fd2ed4b80ccc6094a50032eb25d68c433b14203
+  checksum: 10/c4f7e3c18c8382b72800681c37c87726b02a96cf6831be37d2d2f9c26267016a9dd7af4e08184b96376a9aebdc5c344c6c378c86821c374fe10a9e45aca1b33d
   languageName: node
   linkType: hard
 
@@ -2826,17 +2816,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/utils@npm:8.6.0"
+"@typescript-eslint/utils@npm:8.7.0":
+  version: 8.7.0
+  resolution: "@typescript-eslint/utils@npm:8.7.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.6.0"
-    "@typescript-eslint/types": "npm:8.6.0"
-    "@typescript-eslint/typescript-estree": "npm:8.6.0"
+    "@typescript-eslint/scope-manager": "npm:8.7.0"
+    "@typescript-eslint/types": "npm:8.7.0"
+    "@typescript-eslint/typescript-estree": "npm:8.7.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10/778caa5767d306d17dea8d648baf158eda4099717fd1067d5362446adb7e51af357d4a9a53430327cc7f0229c69347a3b9b434ab937256fb0b4a0e3458184068
+  checksum: 10/81674503fb5ea32ff5de8f1a29fecbcfa947025e7609e861ac8e32cd13326fc050c4fa5044e1a877f05e7e1264c42b9c72a7fd09c4a41d0ac2cf1c49259abf03
   languageName: node
   linkType: hard
 
@@ -2860,13 +2850,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.6.0"
+"@typescript-eslint/visitor-keys@npm:8.7.0":
+  version: 8.7.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.7.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.6.0"
+    "@typescript-eslint/types": "npm:8.7.0"
     eslint-visitor-keys: "npm:^3.4.3"
-  checksum: 10/76d94f33d27fd33c324bb5245ec571bede6f5f22e67f0412abccf603402d55df7f46ea05a36b8bdfe6266bb990e3298f5595292c0b8940a149409064605b5ee9
+  checksum: 10/189ea297ff4da53aea92f31de57aed164550c51ac7cf663007c997c4f0f75a82097e35568e3a0fbcced290cb4c12ab7d3afd99e93eb37c930d7f6d6bbfd6ed98
   languageName: node
   linkType: hard
 
@@ -3240,7 +3230,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"astro-eslint-parser@npm:^1.0.2":
+"astro-eslint-parser@npm:^1.0.2, astro-eslint-parser@npm:^1.0.3":
   version: 1.0.3
   resolution: "astro-eslint-parser@npm:1.0.3"
   dependencies:
@@ -3490,16 +3480,16 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.23.1, browserslist@npm:^4.23.3":
-  version: 4.23.3
-  resolution: "browserslist@npm:4.23.3"
+  version: 4.24.0
+  resolution: "browserslist@npm:4.24.0"
   dependencies:
-    caniuse-lite: "npm:^1.0.30001646"
-    electron-to-chromium: "npm:^1.5.4"
+    caniuse-lite: "npm:^1.0.30001663"
+    electron-to-chromium: "npm:^1.5.28"
     node-releases: "npm:^2.0.18"
     update-browserslist-db: "npm:^1.1.0"
   bin:
     browserslist: cli.js
-  checksum: 10/e266d18c6c6c5becf9a1a7aa264477677b9796387972e8fce34854bb33dc1666194dc28389780e5dc6566e68a95e87ece2ce222e1c4ca93c2b75b61dfebd5f1c
+  checksum: 10/26c1b8ba257a0b51b102080ba9d42945af2abaa8c4cf6da21cd47b3f123fc1e81640203b293214356c2c17d9d265bb3a5ed428b6d302f383576dd6ce8fd5036c
   languageName: node
   linkType: hard
 
@@ -3578,10 +3568,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001646":
-  version: 1.0.30001662
-  resolution: "caniuse-lite@npm:1.0.30001662"
-  checksum: 10/275dee3c2365d58c65609e707dfd7454e72195fdae7d3a8fea05f1ddb49581f64dfc65965964ee2cff99cc0af44d08c572437b1effd43e9ddc174d7a1d7f95a3
+"caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001663":
+  version: 1.0.30001664
+  resolution: "caniuse-lite@npm:1.0.30001664"
+  checksum: 10/ff237f6bbb59564d2a7219fe9a799a59692403115500f7548a77f1f6b82e33fd136375003f80c8df88a64048f699f9f917292ca4cac0dd8a789d2d35fba6269b
   languageName: node
   linkType: hard
 
@@ -4156,9 +4146,9 @@ __metadata:
   linkType: hard
 
 "devalue@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "devalue@npm:5.0.0"
-  checksum: 10/52c4e1b57c3c05dee64f8c64175f53812c4de4fa1a098b238acd74a38c0756b3631ca74081d0141248d27c00c2f18861b6f874298cd68a4fb2e0797b71de4970
+  version: 5.1.1
+  resolution: "devalue@npm:5.1.1"
+  checksum: 10/ff36fe61af61636419eb16692d2fe43d793cdfb17f868bb3560c5485e4c25bc38d472304e61efdec6e806a3c4b450c46247decf59968b4a05ddc7714ea64f885
   languageName: node
   linkType: hard
 
@@ -4226,10 +4216,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.4":
-  version: 1.5.27
-  resolution: "electron-to-chromium@npm:1.5.27"
-  checksum: 10/aaafe122c08cdef30ecf3519e1ef386ab9cf60f5ce2944a690394e3a60f7b090d74461489fc9c8d40cfc8c52b21049c3046c9e073724833c5a77a766c1c05b11
+"electron-to-chromium@npm:^1.5.28":
+  version: 1.5.29
+  resolution: "electron-to-chromium@npm:1.5.29"
+  checksum: 10/a87354db605ffdb89618c328ecc492846f8685f5ba040b9c8b511ef7a1a8e0c8999eb1ce2ea7bac30624637200f31dd1da5dc0cb3b2841ea828790f894a9ec37
   languageName: node
   linkType: hard
 
@@ -4925,14 +4915,14 @@ __metadata:
   linkType: hard
 
 "eslint-module-utils@npm:^2.8.1, eslint-module-utils@npm:^2.9.0":
-  version: 2.11.0
-  resolution: "eslint-module-utils@npm:2.11.0"
+  version: 2.11.1
+  resolution: "eslint-module-utils@npm:2.11.1"
   dependencies:
     debug: "npm:^3.2.7"
   peerDependenciesMeta:
     eslint:
       optional: true
-  checksum: 10/1ba42cf48c5f9ec3b76dfa42c16f1c24c10508313689425c05ccb1d0eaa34bdc5c5b9c0c033cd402e9c429666bd3eb8c6d0c66565b0c00949fae743ad3643c95
+  checksum: 10/88285f758cc2d4a07410a5b765cc2858319075e12bedb65ae26459f1bc5a18c2b154f9026d4acb5049896c3815adb29087fd07b2b04d26beb59182bd6028b121
   languageName: node
   linkType: hard
 
@@ -7525,7 +7515,9 @@ __metadata:
     "@types/prop-types": "npm:^15.7.13"
     "@types/react": "npm:^18.3.9"
     "@types/react-dom": "npm:^18.3.0"
+    "@typescript-eslint/parser": "npm:^8.7.0"
     astro: "npm:^4.15.9"
+    astro-eslint-parser: "npm:^1.0.3"
     chai: "npm:^5.1.1"
     common-tags: "npm:^1.8.2"
     copy-to-clipboard: "npm:^3.3.3"
@@ -8986,12 +8978,12 @@ __metadata:
   linkType: hard
 
 "parse-imports@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "parse-imports@npm:2.1.1"
+  version: 2.2.1
+  resolution: "parse-imports@npm:2.2.1"
   dependencies:
     es-module-lexer: "npm:^1.5.3"
     slashes: "npm:^3.0.12"
-  checksum: 10/466cba090fe8b77aa2edc2a7ebcde699a296f34db5384d89f2c78daa5e7a87979adbad8a478634a85f5546ec8b759b597cf1057d825b471db70ce5c1b0c8bbec
+  checksum: 10/db1d98077587d23bfa1f136abae158ea08e1e588d0260dfc0769092be86b842c798ae47466742b1d9bc106d3430cebbd9730fc34872a2c0e72b9ff720986e82e
   languageName: node
   linkType: hard
 
@@ -10152,16 +10144,16 @@ __metadata:
   linkType: hard
 
 "shiki@npm:^1.10.3, shiki@npm:^1.16.2":
-  version: 1.18.0
-  resolution: "shiki@npm:1.18.0"
+  version: 1.19.0
+  resolution: "shiki@npm:1.19.0"
   dependencies:
-    "@shikijs/core": "npm:1.18.0"
-    "@shikijs/engine-javascript": "npm:1.18.0"
-    "@shikijs/engine-oniguruma": "npm:1.18.0"
-    "@shikijs/types": "npm:1.18.0"
+    "@shikijs/core": "npm:1.19.0"
+    "@shikijs/engine-javascript": "npm:1.19.0"
+    "@shikijs/engine-oniguruma": "npm:1.19.0"
+    "@shikijs/types": "npm:1.19.0"
     "@shikijs/vscode-textmate": "npm:^9.2.2"
     "@types/hast": "npm:^3.0.4"
-  checksum: 10/5b6e6463c89d1e7f0ad692544400ab45896ed1f907a65ff7a027cebdcba14e8e0ccb4cec677a32f71744f59983480a47e259ae80d09698018c3dcc7c4fe9a3f4
+  checksum: 10/ce904dd4fc2da7445617ec08ececabe592748b712d165424fe545bd72b9ff235fe15a4b52cbbaa95d2f266de775ab8dfed87c82bc27c28873213b1dbc3edd341
   languageName: node
   linkType: hard
 
@@ -11293,8 +11285,8 @@ __metadata:
   linkType: hard
 
 "vite@npm:^5.4.3":
-  version: 5.4.7
-  resolution: "vite@npm:5.4.7"
+  version: 5.4.8
+  resolution: "vite@npm:5.4.8"
   dependencies:
     esbuild: "npm:^0.21.3"
     fsevents: "npm:~2.3.3"
@@ -11331,7 +11323,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10/3f27e870930ad83b51e009604c6b69ab090e69bb5bfe85007c7e4ec3326efae4e33ac799645926363f258595b3be3055cc1ebc5ee158cff4bacdf41adf4ef8ed
+  checksum: 10/17fdffa558abaf854f04ead7d3ddd76e4556a59871f9ac63cca3fc20a79979984837d8dddaae4b171e3d73061f781e4eec0f6d3babdbce2b4d111d29cf474c1c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
...to prepare for splitting out components.

Also, lint astro files.

This got rid of the "easy" terrible rerender-triggering arrow-functions-in-event-handlers, but leaves the copying ones around, since they'll be much easier to fix once I split components out a bit more.