### PR TITLE
test: colors in boost sets for element border tracking

### DIFF
--- a/src/components/contract-boost-calculator.tsx
+++ b/src/components/contract-boost-calculator.tsx
@@ -347,6 +347,9 @@ const BoostPresetButtons = () => {
 		[updateData],
 	);
 
+	// we should be able to have the `fieldset` be `#boostSets` to receive
+	// `display: grid`, but then it appears that having the `legend` there
+	// screws up the first render for iOS safari specifically ಠ_ಠ
 	return (
 		<fieldset>
 			<legend>Boost Set</legend>

--- a/src/components/contract-boost-calculator.tsx
+++ b/src/components/contract-boost-calculator.tsx
@@ -348,24 +348,22 @@ const BoostPresetButtons = () => {
 	);
 
 	return (
-		<div className="safariGridContainer">
-			<fieldset id="boostSets">
-				<legend>Boost Set</legend>
-				{boostRadios.map(({ id, label }) => (
-					<div key={id}>
-						<input
-							type="radio"
-							name="boostSet"
-							id={id}
-							value={id}
-							checked={data.boost === id}
-							onChange={handleChange}
-						/>
-						<label htmlFor={id}>{label}</label>
-					</div>
-				))}
-			</fieldset>
-		</div>
+		<fieldset id="boostSets">
+			<legend>Boost Set</legend>
+			{boostRadios.map(({ id, label }) => (
+				<div key={id}>
+					<input
+						type="radio"
+						name="boostSet"
+						id={id}
+						value={id}
+						checked={data.boost === id}
+						onChange={handleChange}
+					/>
+					<label htmlFor={id}>{label}</label>
+				</div>
+			))}
+		</fieldset>
 	);
 };
 

--- a/src/components/contract-boost-calculator.tsx
+++ b/src/components/contract-boost-calculator.tsx
@@ -348,22 +348,24 @@ const BoostPresetButtons = () => {
 	);
 
 	return (
-		<fieldset id="boostSets">
-			<legend>Boost Set</legend>
-			{boostRadios.map(({ id, label }) => (
-				<div key={id}>
-					<input
-						type="radio"
-						name="boostSet"
-						id={id}
-						value={id}
-						checked={data.boost === id}
-						onChange={handleChange}
-					/>
-					<label htmlFor={id}>{label}</label>
-				</div>
-			))}
-		</fieldset>
+		<div className="safariGridContainer">
+			<fieldset id="boostSets">
+				<legend>Boost Set</legend>
+				{boostRadios.map(({ id, label }) => (
+					<div key={id}>
+						<input
+							type="radio"
+							name="boostSet"
+							id={id}
+							value={id}
+							checked={data.boost === id}
+							onChange={handleChange}
+						/>
+						<label htmlFor={id}>{label}</label>
+					</div>
+				))}
+			</fieldset>
+		</div>
 	);
 };
 

--- a/src/components/contract-boost-calculator.tsx
+++ b/src/components/contract-boost-calculator.tsx
@@ -348,21 +348,23 @@ const BoostPresetButtons = () => {
 	);
 
 	return (
-		<fieldset id="boostSets">
+		<fieldset>
 			<legend>Boost Set</legend>
-			{boostRadios.map(({ id, label }) => (
-				<div key={id}>
-					<input
-						type="radio"
-						name="boostSet"
-						id={id}
-						value={id}
-						checked={data.boost === id}
-						onChange={handleChange}
-					/>
-					<label htmlFor={id}>{label}</label>
-				</div>
-			))}
+			<div id="boostSets">
+				{boostRadios.map(({ id, label }) => (
+					<div key={id}>
+						<input
+							type="radio"
+							name="boostSet"
+							id={id}
+							value={id}
+							checked={data.boost === id}
+							onChange={handleChange}
+						/>
+						<label htmlFor={id}>{label}</label>
+					</div>
+				))}
+			</div>
 		</fieldset>
 	);
 };

--- a/src/pages/contract-boost-calculator.astro
+++ b/src/pages/contract-boost-calculator.astro
@@ -121,10 +121,7 @@ const api = process.env.NEXT_PUBLIC_API_URL;
 	#boostSets {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(min(15em, 100%), 1fr));
-		grid-template-rows: auto;
 		gap: 1rem;
-		border: 2px solid blue;
-		height: fit-content;
 
 		& div {
 			display: flex;
@@ -135,7 +132,6 @@ const api = process.env.NEXT_PUBLIC_API_URL;
 		}
 		& label {
 			width: max-content;
-			background-color: green;
 		}
 	}
 

--- a/src/pages/contract-boost-calculator.astro
+++ b/src/pages/contract-boost-calculator.astro
@@ -115,20 +115,15 @@ const api = process.env.NEXT_PUBLIC_API_URL;
 		}
 	}
 
-	.safariGridContainer {
-		display: grid;
-	}
 	#boostSets {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(min(15em, 100%), 1fr));
 		gap: 1rem;
-
 		& div {
 			display: flex;
 			flex-direction: row;
 			gap: 0.5em;
 			width: fit-content;
-			background-color: red;
 		}
 		& label {
 			width: max-content;

--- a/src/pages/contract-boost-calculator.astro
+++ b/src/pages/contract-boost-calculator.astro
@@ -119,14 +119,18 @@ const api = process.env.NEXT_PUBLIC_API_URL;
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(min(15em, 100%), 1fr));
 		gap: 1rem;
+		border: 2px solid blue;
+
 		& div {
 			display: flex;
 			flex-direction: row;
 			gap: 0.5em;
 			width: fit-content;
+			background-color: red;
 		}
 		& label {
 			width: max-content;
+			background-color: green;
 		}
 	}
 

--- a/src/pages/contract-boost-calculator.astro
+++ b/src/pages/contract-boost-calculator.astro
@@ -118,6 +118,7 @@ const api = process.env.NEXT_PUBLIC_API_URL;
 	#boostSets {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(min(15em, 100%), 1fr));
+		grid-template-rows: auto;
 		gap: 1rem;
 		border: 2px solid blue;
 
@@ -127,7 +128,6 @@ const api = process.env.NEXT_PUBLIC_API_URL;
 			gap: 0.5em;
 			width: fit-content;
 			background-color: red;
-			max-height: 1lh;
 		}
 		& label {
 			width: max-content;

--- a/src/pages/contract-boost-calculator.astro
+++ b/src/pages/contract-boost-calculator.astro
@@ -121,6 +121,7 @@ const api = process.env.NEXT_PUBLIC_API_URL;
 		grid-template-rows: auto;
 		gap: 1rem;
 		border: 2px solid blue;
+		height: fit-content;
 
 		& div {
 			display: flex;

--- a/src/pages/contract-boost-calculator.astro
+++ b/src/pages/contract-boost-calculator.astro
@@ -127,6 +127,7 @@ const api = process.env.NEXT_PUBLIC_API_URL;
 			gap: 0.5em;
 			width: fit-content;
 			background-color: red;
+			max-height: 1lh;
 		}
 		& label {
 			width: max-content;

--- a/src/pages/contract-boost-calculator.astro
+++ b/src/pages/contract-boost-calculator.astro
@@ -115,6 +115,9 @@ const api = process.env.NEXT_PUBLIC_API_URL;
 		}
 	}
 
+	.safariGridContainer {
+		display: grid;
+	}
 	#boostSets {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(min(15em, 100%), 1fr));


### PR DESCRIPTION
apparently having the `<legend>` of a fieldset throws off `grid` rendering in some versions of safari. this moves the grid container for the boost set selection to _only_ include the inputs, and not the `<legend>`, which appears to unfuck it